### PR TITLE
[1.20.1] JEED compatiblity + piglins accept thermometer as gold

### DIFF
--- a/src/main/resources/assets/cold_sweat/lang/en_us.json
+++ b/src/main/resources/assets/cold_sweat/lang/en_us.json
@@ -293,6 +293,15 @@
   "attribute.cold_sweat.modifier.add.world_temperature":      "%d° Environment Temperature",
   "attribute.cold_sweat.modifier.multiply.world_temperature": "%d Environment Temperature",
 
+  "effect.cold_sweat.frigidness.desc": "Decreases and stabilizes the world temperature for the player. Higher levels provide a more habitable temperature in frigid environments."
+  "effect.cold_sweat.grace.desc": "Grants complete immunity to temperature-based damage. \n\nOnly obtainable when joining a world for the first time."
+  "effect.cold_sweat.ice_resistance.desc": "Grants immunity to freezing damage, as well as damage from powdered snow."
+  "effect.cold_sweat.frigidness.desc": "Increases and stabilizes the world temperature for the player. Higher levels provide a more habitable temperature in hot environments."
+  "effect.cold_sweat.frigidness.description": "Decreases and stabilizes the world temperature for the player. Higher levels provide a more habitable temperature in frigid environments."
+  "effect.cold_sweat.grace.description": "Grants complete immunity to temperature-based damage. \n\nOnly obtainable when joining a world for the first time."
+  "effect.cold_sweat.ice_resistance.description": "Grants immunity to freezing damage, as well as damage from powdered snow."
+  "effect.cold_sweat.frigidness.description": "Increases and stabilizes the world temperature for the player. Higher levels provide a more habitable temperature in hot environments."
+
   "message.cold_sweat.mod_name": "Cold Sweat",
   "message.cold_sweat.warning": "Warning!",
   "message.cold_sweat.disable": "click to disable",

--- a/src/main/resources/assets/cold_sweat/lang/en_us.json
+++ b/src/main/resources/assets/cold_sweat/lang/en_us.json
@@ -296,11 +296,11 @@
   "effect.cold_sweat.frigidness.desc": "Decreases and stabilizes the world temperature for the player. Higher levels provide a more habitable temperature in frigid environments."
   "effect.cold_sweat.grace.desc": "Grants complete immunity to temperature-based damage. \n\nOnly obtainable when joining a world for the first time."
   "effect.cold_sweat.ice_resistance.desc": "Grants immunity to freezing damage, as well as damage from powdered snow."
-  "effect.cold_sweat.frigidness.desc": "Increases and stabilizes the world temperature for the player. Higher levels provide a more habitable temperature in hot environments."
+  "effect.cold_sweat.warmth.desc": "Increases and stabilizes the world temperature for the player. Higher levels provide a more habitable temperature in hot environments."
   "effect.cold_sweat.frigidness.description": "Decreases and stabilizes the world temperature for the player. Higher levels provide a more habitable temperature in frigid environments."
   "effect.cold_sweat.grace.description": "Grants complete immunity to temperature-based damage. \n\nOnly obtainable when joining a world for the first time."
   "effect.cold_sweat.ice_resistance.description": "Grants immunity to freezing damage, as well as damage from powdered snow."
-  "effect.cold_sweat.frigidness.description": "Increases and stabilizes the world temperature for the player. Higher levels provide a more habitable temperature in hot environments."
+  "effect.cold_sweat.warmth.description": "Increases and stabilizes the world temperature for the player. Higher levels provide a more habitable temperature in hot environments."
 
   "message.cold_sweat.mod_name": "Cold Sweat",
   "message.cold_sweat.warning": "Warning!",

--- a/src/main/resources/data/cold_sweat/recipes/compat/jeed/frigidness.json
+++ b/src/main/resources/data/cold_sweat/recipes/compat/jeed/frigidness.json
@@ -1,0 +1,15 @@
+{
+  "conditions": [
+    {
+      "modid": "jeed",
+      "type": "forge:mod_loaded"
+    }
+  ],
+  "type": "jeed:effect_provider",
+  "effect": "cold_sweat:frigidness",
+  "providers": [
+    {
+      "item": "cold_sweat:hearth"
+    }
+  ]
+}

--- a/src/main/resources/data/cold_sweat/recipes/compat/jeed/warmth.json
+++ b/src/main/resources/data/cold_sweat/recipes/compat/jeed/warmth.json
@@ -1,0 +1,15 @@
+{
+  "conditions": [
+    {
+      "modid": "supplementaries",
+      "type": "forge:mod_loaded"
+    }
+  ],
+  "type": "jeed:effect_provider",
+  "effect": "cold_sweat:warmth",
+  "providers": [
+    {
+      "tag": "cold_sweat:hearth"
+    }
+  ]
+}

--- a/src/main/resources/data/cold_sweat/recipes/compat/jeed/warmth.json
+++ b/src/main/resources/data/cold_sweat/recipes/compat/jeed/warmth.json
@@ -1,7 +1,7 @@
 {
   "conditions": [
     {
-      "modid": "supplementaries",
+      "modid": "jeed",
       "type": "forge:mod_loaded"
     }
   ],

--- a/src/main/resources/data/cold_sweat/recipes/compat/jeed/warmth.json
+++ b/src/main/resources/data/cold_sweat/recipes/compat/jeed/warmth.json
@@ -9,7 +9,7 @@
   "effect": "cold_sweat:warmth",
   "providers": [
     {
-      "tag": "cold_sweat:hearth"
+      "item": "cold_sweat:hearth"
     }
   ]
 }

--- a/src/main/resources/data/minecraft/tags/items/piglin_loved.json
+++ b/src/main/resources/data/minecraft/tags/items/piglin_loved.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "cold_sweat:thermometer"
+  ]
+}


### PR DESCRIPTION
### Goals
* Adds descriptions to all four Cold Sweat mob effects
* Adds compatibility with Just Enough Effect Descriptions (JEED) by adding custom recipe types for two mob effects
* Adds `cold_sweat:thermometer` to `minecraft:piglin_loved` item tag, allowing Piglins to accept thermometers as a "currency"

### Notes
**Has not been tested.**