### PR TITLE
Iceberg 1.3.x support.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -152,7 +152,7 @@ dependencies {
     implementation "curse.maven:glitchcore-955399:5645390"
     implementation "curse.maven:spoiled-364918:5490658"
     implementation "curse.maven:curios-continuation-1037991:5747224"
-    implementation "curse.maven:iceberg-520110:5590963"
+    implementation "curse.maven:iceberg-520110:6379432"
     implementation "curse.maven:create-328085:6247669"
     compileOnly("net.createmod.ponder:Ponder-NeoForge-1.21.1:1.0.39")
 

--- a/src/main/java/com/momosoftworks/coldsweat/compat/CompatManager.java
+++ b/src/main/java/com/momosoftworks/coldsweat/compat/CompatManager.java
@@ -1,6 +1,6 @@
 package com.momosoftworks.coldsweat.compat;
 
-import com.anthonyhilyard.iceberg.util.Tooltips;
+import com.anthonyhilyard.iceberg.component.TitleBreakComponent;
 import com.mojang.datafixers.util.Either;
 import com.momosoftworks.coldsweat.ColdSweat;
 import com.momosoftworks.coldsweat.api.event.core.init.FetchSeasonsModsEvent;
@@ -71,7 +71,7 @@ public class CompatManager
     private static final boolean TOOLTIPS_LOADED = modLoaded("legendarytooltips");
     private static final boolean PRIMAL_WINTER_LOADED = modLoaded("primalwinter");
     private static final boolean THIRST_LOADED = modLoaded("thirst", "1.21.0-2.1.0");
-    private static final boolean ICEBERG_LOADED = modLoaded("iceberg");
+    private static final boolean ICEBERG_LOADED = modLoaded("iceberg", "1.3.0");
     private static final boolean SPOILED_LOADED = modLoaded("spoiled");
     private static final boolean SUPPLEMENTARIES_LOADED = modLoaded("supplementaries");
     private static final boolean TOUGH_AS_NAILS_LOADED = modLoaded("toughasnails");
@@ -351,7 +351,7 @@ public class CompatManager
             {
                 public int getLegendaryTTStartIndex()
                 {
-                    int index = CSMath.getIndexOf(tooltip, element -> element.right().map(component -> component instanceof Tooltips.TitleBreakComponent).orElse(false));
+                    int index = CSMath.getIndexOf(tooltip, element -> element.right().map(component -> component instanceof TitleBreakComponent).orElse(false));
                     if (index == -1) return 0;
                     return index;
                 }


### PR DESCRIPTION
The TitleBreakComponent in Iceberg was relocated in version 1.3.0.  This PR fixes a crash when Cold Sweat is used in conjunction with that version of Iceberg or higher.